### PR TITLE
Fix regex error on POSIX-systems with MUSL

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 VERSION = 2.11
-CC = gcc -std=c18
+CC ?= gcc -std=c18
 CFLAGS = -O3 -march=native -Wall -Wextra -Wno-implicit-fallthrough -Wpedantic
 LDFLAGS =
 TARGET = reliq

--- a/src/lib/pattern.c
+++ b/src/lib/pattern.c
@@ -348,12 +348,22 @@ regexec_match_pattern(const reliq_pattern *pattern, reliq_cstr *str)
     if (!str->s)
       return 0;
 
+#ifdef REG_STARTEND
     regmatch_t pmatch;
     pmatch.rm_so = 0;
     pmatch.rm_eo = (int)str->s;
 
     if (regexec(&pattern->match.reg,str->b,1,&pmatch,REG_STARTEND) == 0)
       return 1;
+#else
+    char *tmp = malloc(str->s + 1);
+    memcpy(tmp, str->b, str->s);
+    tmp[str->s] = '\0';
+    
+    int result = (regexec(&pattern->match.reg, tmp, 0, NULL, 0) == 0);
+    free(tmp);
+    return result;
+#endif
   }
   return 0;
 }


### PR DESCRIPTION
This fixes #5 on system with MUSL. Tested and confirmed I was able to compile


```
alpine1:~/reliq# make lib-install
rm -f reliq libreliq.so src/flexarr.o src/lib/sink.o src/lib/html.o src/lib/hnode.o src/lib/reliq.o src/lib/hnode_print.o src/lib/ctype.o src/lib/utils.o src/lib/output.o src/lib/entities.o src/lib/pattern.o src/lib/range.o src/lib/exprs_comp.o src/lib/exprs_exec.o src/lib/format.o src/lib/npattern_comp.o src/lib/npattern_exec.o src/lib/node_exec.o src/lib/edit.o src/lib/edit_sed.o src/lib/edit_wc.o src/lib/edit_tr.o src/lib/url.o src/lib/scheme.o src/lib/fields.o src/cli/main.o src/cli/usage.o src/cli/pretty.o reliq.h reliq-2.11.tar.xz
make[1]: Entering directory '/root/reliq'
src/flexarr.c src/lib/sink.c src/lib/html.c src/lib/hnode.c src/lib/reliq.c src/lib/hnode_print.c src/lib/ctype.c src/lib/utils.c src/lib/output.c src/lib/entities.c src/lib/pattern.c src/lib/range.c src/lib/exprs_comp.c src/lib/exprs_exec.c src/lib/format.c src/lib/npattern_comp.c src/lib/npattern_exec.c src/lib/node_exec.c src/lib/edit.c src/lib/edit_sed.c src/lib/edit_wc.c src/lib/edit_tr.c src/lib/url.c src/lib/scheme.c src/lib/fields.c
libreliq.so build options:
CFLAGS   = -DRELIQ_VERSION="2.11" -DRELIQ_HTML_SIZE=1  -DRELIQ_PHPTAGS -DRELIQ_AUTOCLOSING -O3 -march=native -Wall -Wextra -Wno-implicit-fallthrough -Wpedantic -fPIC
LDFLAGS  = -shared
CC       = cc
cc -DRELIQ_VERSION=\"2.11\" -DRELIQ_HTML_SIZE=1  -DRELIQ_PHPTAGS -DRELIQ_AUTOCLOSING -O3 -march=native -Wall -Wextra -Wno-implicit-fallthrough -Wpedantic -fPIC -c src/flexarr.c -o src/flexarr.o
cc -DRELIQ_VERSION=\"2.11\" -DRELIQ_HTML_SIZE=1  -DRELIQ_PHPTAGS -DRELIQ_AUTOCLOSING -O3 -march=native -Wall -Wextra -Wno-implicit-fallthrough -Wpedantic -fPIC -c src/lib/sink.c -o src/lib/sink.o
cc -DRELIQ_VERSION=\"2.11\" -DRELIQ_HTML_SIZE=1  -DRELIQ_PHPTAGS -DRELIQ_AUTOCLOSING -O3 -march=native -Wall -Wextra -Wno-implicit-fallthrough -Wpedantic -fPIC -c src/lib/html.c -o src/lib/html.o
cc -DRELIQ_VERSION=\"2.11\" -DRELIQ_HTML_SIZE=1  -DRELIQ_PHPTAGS -DRELIQ_AUTOCLOSING -O3 -march=native -Wall -Wextra -Wno-implicit-fallthrough -Wpedantic -fPIC -c src/lib/hnode.c -o src/lib/hnode.o
cc -DRELIQ_VERSION=\"2.11\" -DRELIQ_HTML_SIZE=1  -DRELIQ_PHPTAGS -DRELIQ_AUTOCLOSING -O3 -march=native -Wall -Wextra -Wno-implicit-fallthrough -Wpedantic -fPIC -c src/lib/reliq.c -o src/lib/reliq.o
cc -DRELIQ_VERSION=\"2.11\" -DRELIQ_HTML_SIZE=1  -DRELIQ_PHPTAGS -DRELIQ_AUTOCLOSING -O3 -march=native -Wall -Wextra -Wno-implicit-fallthrough -Wpedantic -fPIC -c src/lib/hnode_print.c -o src/lib/hnode_print.o
cc -DRELIQ_VERSION=\"2.11\" -DRELIQ_HTML_SIZE=1  -DRELIQ_PHPTAGS -DRELIQ_AUTOCLOSING -O3 -march=native -Wall -Wextra -Wno-implicit-fallthrough -Wpedantic -fPIC -c src/lib/ctype.c -o src/lib/ctype.o
cc -DRELIQ_VERSION=\"2.11\" -DRELIQ_HTML_SIZE=1  -DRELIQ_PHPTAGS -DRELIQ_AUTOCLOSING -O3 -march=native -Wall -Wextra -Wno-implicit-fallthrough -Wpedantic -fPIC -c src/lib/utils.c -o src/lib/utils.o
cc -DRELIQ_VERSION=\"2.11\" -DRELIQ_HTML_SIZE=1  -DRELIQ_PHPTAGS -DRELIQ_AUTOCLOSING -O3 -march=native -Wall -Wextra -Wno-implicit-fallthrough -Wpedantic -fPIC -c src/lib/output.c -o src/lib/output.o
cc -DRELIQ_VERSION=\"2.11\" -DRELIQ_HTML_SIZE=1  -DRELIQ_PHPTAGS -DRELIQ_AUTOCLOSING -O3 -march=native -Wall -Wextra -Wno-implicit-fallthrough -Wpedantic -fPIC -c src/lib/entities.c -o src/lib/entities.o
cc -DRELIQ_VERSION=\"2.11\" -DRELIQ_HTML_SIZE=1  -DRELIQ_PHPTAGS -DRELIQ_AUTOCLOSING -O3 -march=native -Wall -Wextra -Wno-implicit-fallthrough -Wpedantic -fPIC -c src/lib/pattern.c -o src/lib/pattern.o
cc -DRELIQ_VERSION=\"2.11\" -DRELIQ_HTML_SIZE=1  -DRELIQ_PHPTAGS -DRELIQ_AUTOCLOSING -O3 -march=native -Wall -Wextra -Wno-implicit-fallthrough -Wpedantic -fPIC -c src/lib/range.c -o src/lib/range.o
cc -DRELIQ_VERSION=\"2.11\" -DRELIQ_HTML_SIZE=1  -DRELIQ_PHPTAGS -DRELIQ_AUTOCLOSING -O3 -march=native -Wall -Wextra -Wno-implicit-fallthrough -Wpedantic -fPIC -c src/lib/exprs_comp.c -o src/lib/exprs_comp.o
cc -DRELIQ_VERSION=\"2.11\" -DRELIQ_HTML_SIZE=1  -DRELIQ_PHPTAGS -DRELIQ_AUTOCLOSING -O3 -march=native -Wall -Wextra -Wno-implicit-fallthrough -Wpedantic -fPIC -c src/lib/exprs_exec.c -o src/lib/exprs_exec.o
cc -DRELIQ_VERSION=\"2.11\" -DRELIQ_HTML_SIZE=1  -DRELIQ_PHPTAGS -DRELIQ_AUTOCLOSING -O3 -march=native -Wall -Wextra -Wno-implicit-fallthrough -Wpedantic -fPIC -c src/lib/format.c -o src/lib/format.o
cc -DRELIQ_VERSION=\"2.11\" -DRELIQ_HTML_SIZE=1  -DRELIQ_PHPTAGS -DRELIQ_AUTOCLOSING -O3 -march=native -Wall -Wextra -Wno-implicit-fallthrough -Wpedantic -fPIC -c src/lib/npattern_comp.c -o src/lib/npattern_comp.o
cc -DRELIQ_VERSION=\"2.11\" -DRELIQ_HTML_SIZE=1  -DRELIQ_PHPTAGS -DRELIQ_AUTOCLOSING -O3 -march=native -Wall -Wextra -Wno-implicit-fallthrough -Wpedantic -fPIC -c src/lib/npattern_exec.c -o src/lib/npattern_exec.o
cc -DRELIQ_VERSION=\"2.11\" -DRELIQ_HTML_SIZE=1  -DRELIQ_PHPTAGS -DRELIQ_AUTOCLOSING -O3 -march=native -Wall -Wextra -Wno-implicit-fallthrough -Wpedantic -fPIC -c src/lib/node_exec.c -o src/lib/node_exec.o
cc -DRELIQ_VERSION=\"2.11\" -DRELIQ_HTML_SIZE=1  -DRELIQ_PHPTAGS -DRELIQ_AUTOCLOSING -O3 -march=native -Wall -Wextra -Wno-implicit-fallthrough -Wpedantic -fPIC -c src/lib/edit.c -o src/lib/edit.o
cc -DRELIQ_VERSION=\"2.11\" -DRELIQ_HTML_SIZE=1  -DRELIQ_PHPTAGS -DRELIQ_AUTOCLOSING -O3 -march=native -Wall -Wextra -Wno-implicit-fallthrough -Wpedantic -fPIC -c src/lib/edit_sed.c -o src/lib/edit_sed.o
src/lib/edit_sed.c: In function 'sed_address_exec':
src/lib/edit_sed.c:205:14: warning: unused variable 'pmatch' [-Wunused-variable]
  205 |   regmatch_t pmatch;
      |              ^~~~~~
cc -DRELIQ_VERSION=\"2.11\" -DRELIQ_HTML_SIZE=1  -DRELIQ_PHPTAGS -DRELIQ_AUTOCLOSING -O3 -march=native -Wall -Wextra -Wno-implicit-fallthrough -Wpedantic -fPIC -c src/lib/edit_wc.c -o src/lib/edit_wc.o
cc -DRELIQ_VERSION=\"2.11\" -DRELIQ_HTML_SIZE=1  -DRELIQ_PHPTAGS -DRELIQ_AUTOCLOSING -O3 -march=native -Wall -Wextra -Wno-implicit-fallthrough -Wpedantic -fPIC -c src/lib/edit_tr.c -o src/lib/edit_tr.o
cc -DRELIQ_VERSION=\"2.11\" -DRELIQ_HTML_SIZE=1  -DRELIQ_PHPTAGS -DRELIQ_AUTOCLOSING -O3 -march=native -Wall -Wextra -Wno-implicit-fallthrough -Wpedantic -fPIC -c src/lib/url.c -o src/lib/url.o
cc -DRELIQ_VERSION=\"2.11\" -DRELIQ_HTML_SIZE=1  -DRELIQ_PHPTAGS -DRELIQ_AUTOCLOSING -O3 -march=native -Wall -Wextra -Wno-implicit-fallthrough -Wpedantic -fPIC -c src/lib/scheme.c -o src/lib/scheme.o
cc -DRELIQ_VERSION=\"2.11\" -DRELIQ_HTML_SIZE=1  -DRELIQ_PHPTAGS -DRELIQ_AUTOCLOSING -O3 -march=native -Wall -Wextra -Wno-implicit-fallthrough -Wpedantic -fPIC -c src/lib/fields.c -o src/lib/fields.o
cc -DRELIQ_VERSION=\"2.11\" -DRELIQ_HTML_SIZE=1  -DRELIQ_PHPTAGS -DRELIQ_AUTOCLOSING -O3 -march=native -Wall -Wextra -Wno-implicit-fallthrough -Wpedantic -fPIC src/flexarr.o src/lib/sink.o src/lib/html.o src/lib/hnode.o src/lib/reliq.o src/lib/hnode_print.o src/lib/ctype.o src/lib/utils.o src/lib/output.o src/lib/entities.o src/lib/pattern.o src/lib/range.o src/lib/exprs_comp.o src/lib/exprs_exec.o src/lib/format.o src/lib/npattern_comp.o src/lib/npattern_exec.o src/lib/node_exec.o src/lib/edit.o src/lib/edit_sed.o src/lib/edit_wc.o src/lib/edit_tr.o src/lib/url.o src/lib/scheme.o src/lib/fields.o  -shared -o libreliq.so
[ "0" -eq 0 ] && strip  libreliq.so || true
make[1]: Leaving directory '/root/reliq'
sed "s/#VERSION#/2.11/g;s|#PREFIX#|/usr|g;s/#CFLAGS_D#/-DRELIQ_VERSION=\"2.11\" -DRELIQ_HTML_SIZE=1  -DRELIQ_PHPTAGS -DRELIQ_AUTOCLOSING/g" reliq.pc > $(pkg-config --variable pc_path pkg-config | cut -d: -f1)/reliq.pc
install -m755 libreliq.so /usr/lib
install -m644 reliq.h /usr/include
```